### PR TITLE
Add code to query groups and group_types from API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .yardoc
 doc
 Gemfile.lock
+tags

--- a/lib/namely/collection.rb
+++ b/lib/namely/collection.rb
@@ -71,6 +71,12 @@ module Namely
       raise NoSuchModelError, "Can't find any #{endpoint} with id \"#{id}\""
     end
 
+    def find_from(id, find_from=nil)
+      resource_gateway.json_find_from(id, find_from).map { |model| build(model) }
+    rescue RestClient::ResourceNotFound
+      raise NoSuchModelError, "Can't find any #{endpoint} with id \"#{id}\""
+    end
+
     private
 
     attr_reader :resource_gateway

--- a/lib/namely/connection.rb
+++ b/lib/namely/connection.rb
@@ -8,8 +8,8 @@ module Namely
     #
     # @example
     #   Namely.configure do |config|
-    #     config.access_token = "your_access_token"
-    #     config.subdomain = "your-organization"
+    #     config.access_token = 'your_access_token'
+    #     config.subdomain = 'your-organization'
     #   end
     #
     # @raise [KeyError] if access_token and subdomain aren't provided.
@@ -19,63 +19,75 @@ module Namely
       @access_token = options.fetch(:access_token)
       @subdomain = options.fetch(:subdomain)
     rescue KeyError
-      raise ArgumentError, "Please supply an access_token and subdomain."
+      raise ArgumentError, 'Please supply an access_token and subdomain.'
     end
 
     # Return a Collection of countries.
     #
     # @return [Collection]
     def countries
-      collection("countries")
+      collection('countries')
     end
 
     # Return a Collection of currency types.
     #
     # @return [Collection]
     def currency_types
-      collection("currency_types")
+      collection('currency_types')
     end
 
     # Return a Collection of countries.
     #
     # @return [Collection]
     def events
-      collection("events")
+      collection('events')
     end
 
     # Return a Collection of profile fields.
     #
     # @return [Collection]
     def fields
-      collection("profiles/fields")
+      collection('profiles/fields')
     end
 
     # Return a Collection of job tiers.
     #
     # @return [Collection]
     def job_tiers
-      collection("job_tiers")
+      collection('job_tiers')
     end
 
     # Return a Collection of job titles.
     #
     # @return [Collection]
     def job_titles
-      collection("job_titles")
+      collection('job_titles')
     end
 
     # Return a Collection of profiles.
     #
     # @return [Collection]
     def profiles
-      collection("profiles", paged: true)
+      collection('profiles', paged: true)
     end
 
     # Return a Collection of reports.
     #
     # @return [Collection]
     def reports
-      collection("reports")
+      collection('reports')
+    end
+
+    def group_types
+      collection('group_types')
+    end
+
+    def groups
+      collection('groups', paged: true)
+    end
+
+    def groups_by_group_type(group_type_id)
+      group_types.find_from(group_type_id, 'groups')
     end
 
     private
@@ -90,7 +102,7 @@ module Namely
       ResourceGateway.new(options.merge(
         access_token: access_token,
         endpoint: endpoint,
-        subdomain: subdomain,
+        subdomain: subdomain
       ))
     end
   end

--- a/namely.gemspec
+++ b/namely.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rest-client"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
#### Root causes
https://tinyhr.atlassian.net/browse/SYM-272
https://tinyhr.atlassian.net/browse/SYM-391

We need a way to detect the group type from the user profile on Namely.

#### Changes
- Support `client.groups.all`
- Support `client.group_types.all`
- Support `client.groups_by_group_type(group_type_id)`